### PR TITLE
Reexport markdown-utils types from index.d.ts

### DIFF
--- a/packages/gatsby-transformer-markdown-references/index.d.ts
+++ b/packages/gatsby-transformer-markdown-references/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./lib/markdown-utils";

--- a/packages/gatsby-transformer-markdown-references/package.json
+++ b/packages/gatsby-transformer-markdown-references/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.5",
   "description": "Transform markdown nodes to add the necesserary references for bi-directional links",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "npm run clean && ../../node_modules/.bin/tsc -p ./tsconfig.json",
     "watch": "npm run build -- --watch",


### PR DESCRIPTION
Fixes

```
Could not find a declaration file for module 'gatsby-transformer-markdown-references'. '/repository/node_modules/gatsby-transformer-markdown-references/index.js' implicitly has an 'any' type.
  Try `npm install @types/gatsby-transformer-markdown-references` if it exists or add a new declaration (.d.ts) file containing `declare module 'gatsby-transformer-markdown-references';`ts(7016)
```