### PR TITLE
Fixed wrong note type in the Readme

### DIFF
--- a/packages/gatsby-transformer-markdown-references/README.md
+++ b/packages/gatsby-transformer-markdown-references/README.md
@@ -20,7 +20,7 @@ module.exports = {
     {
       resolve: `gatsby-transformer-markdown-references`,
       options: {
-        types: ["Mdx"], // or ['RemarkMarkdown'] (or both)
+        types: ["Mdx"], // or ["MarkdownRemark"] (or both)
       },
     },
   ],


### PR DESCRIPTION
Hey, thanks for your work! 

This fixes a typo in the readme :) 
The other node type apart from `Mdx` is `MarkdownRemark` and not `RemarkMarkdown`