### PR TITLE
fix: update top bar more selector

### DIFF
--- a/packages/fetch-roamresearch/src/index.ts
+++ b/packages/fetch-roamresearch/src/index.ts
@@ -16,7 +16,7 @@ type Reporter = {
   info(log: string): void;
 };
 
-const topBarMoreSelector = `.roam-topbar .bp3-icon-more`;
+const topBarMoreSelector = `.rm-topbar .bp3-icon-more`;
 
 async function click(page: puppeteer.Page, xpath: string) {
   await page.waitForXPath(xpath);


### PR DESCRIPTION
The CSS schema on Roam has changed, specifically the topbar class has changed from from roam-topbar to rm-topbar

This partially addresses #84 