### PR TITLE
fix: clear login input before typing

### DIFF
--- a/packages/fetch-roamresearch/src/index.ts
+++ b/packages/fetch-roamresearch/src/index.ts
@@ -56,6 +56,9 @@ async function checkLogin(
 
   if (state === LOGIN_STATE.NEED) {
     options?.reporter?.info("Login into Roam Research...");
+    // clear input
+    await page.type('input[name="email"]','');
+    await page.type('input[name="password"]', '');
     await page.type('input[name="email"]', auth.email);
     await page.type('input[name="password"]', auth.password);
     const [loginButton] = await page.$x("//button[text()='Sign In']");


### PR DESCRIPTION
This solves a race condition on the login form which results in email or password being input more than once and results in an invalid login.

This addresses #84 