### PR TITLE
Fix misleading error that references contentful

### DIFF
--- a/packages/gatsby-source-roamresearch/src/on-pre-bootstrap.ts
+++ b/packages/gatsby-source-roamresearch/src/on-pre-bootstrap.ts
@@ -17,7 +17,7 @@ export const onPreBoostrap = (
   }
 
   if (errors.length) {
-    reporter.panic(`Problems with gatsby-source-contentful plugin options:
+    reporter.panic(`Problems with gatsby-source-roamresearch plugin options:
 ${errors.join("\n")}`);
   }
 };


### PR DESCRIPTION
`on-pre-bootstrap.ts` has an error message "Problems with gatsby-source-contentful plugin options:" changed to "Problems with gatsby-source-roamresearch plugin options:"