### PR TITLE
Allow processing of aliased wikilinks

### DIFF
--- a/packages/gatsby-transformer-markdown-references/src/compute-inbounds.ts
+++ b/packages/gatsby-transformer-markdown-references/src/compute-inbounds.ts
@@ -43,6 +43,8 @@ export async function generateData(cache: any, getNode: Function) {
     const inboundReferences: { [id: string]: Node[] } = {};
 
     function getRef(title: string) {
+      title =
+        title.indexOf("|") > -1 ? title.substr(0, title.indexOf("|")) : title;
       return nodes.find(
         (x) =>
           x.title === title ||


### PR DESCRIPTION
As mentioned in #85 it would be great if aliased WikiLinks are supported. Fiddling around in my local environment, together with the plugin developed by @johackim, this would ensure the slug of the references only contain the part before the alias. Allowing all matching functions to work.

@mathieudutour I am really new to Gatsby and this project, so perhaps I am not making the best change here. Please notify me if something needs to be changed to make it fit in the philosophy of the project.