### PR TITLE
Add text-orientation property to labels. So that CJK  characters also appear sideway vertically.

### DIFF
--- a/packages/gatsby-theme-garden/src/components/note-wrapper.css
+++ b/packages/gatsby-theme-garden/src/components/note-wrapper.css
@@ -20,6 +20,7 @@
   line-height: 40px;
   font-weight: 500;
   writing-mode: vertical-lr;
+  text-orientation: sideways;
   margin-top: 36px;
   top: 0px;
   bottom: 0px;


### PR DESCRIPTION
This enables CJK texts to appear sideways.
Reference: https://www.w3.org/International/articles/vertical-text/

As-is:
<img width="41" alt="image" src="https://user-images.githubusercontent.com/44766242/124782332-1d478880-df7f-11eb-99a1-cbcec00fee91.png">

To-be:
<img width="38" alt="image" src="https://user-images.githubusercontent.com/44766242/124782418-2cc6d180-df7f-11eb-8ed7-f5d91618095a.png">

